### PR TITLE
Add CircleGuardBench

### DIFF
--- a/Large Language Models/Awesome AI Security.md
+++ b/Large Language Models/Awesome AI Security.md
@@ -59,6 +59,7 @@ If you want to contribute, create a PR or contact me [@ottosulin](https://twitte
 * [rebuff](https://github.com/woop/rebuff) - _Prompt Injection Detector_
 * [langkit](https://github.com/whylabs/langkit) - _LangKit is an open-source text metrics toolkit for monitoring language models. The toolkit various security related metrics that can be used to detect attacks_
 * [StringSifter](https://github.com/fireeye/stringsifter) - _A machine learning tool that ranks strings based on their relevance for malware analysis_
+* [CircleGuardBench](https://github.com/whitecircle-ai/circle-guard-bench) - _CircleGuardBench is a full-fledged benchmark for evaluating protection capabilities of AI models_
 
 ### Privacy and confidentiality
 * [Python Differential Privacy Library](https://github.com/OpenMined/PyDP)


### PR DESCRIPTION
Hi!
I’d be glad if you could take a look at the following work and consider adding it to the relevant sections:

CircleGuardBench – A full-fledged benchmark for evaluating protection capabilities of AI models
• Repository: https://github.com/whitecircle-ai/circle-guard-bench
• Blog post explaining the methodology: https://huggingface.co/blog/whitecircle-ai/circleguardbench
• Hugging Face Leaderboard: https://huggingface.co/spaces/whitecircle-ai/circle-guard-bench
• Dataset: https://huggingface.co/datasets/whitecircle-ai/circleguardbench_public